### PR TITLE
An inconsistency and an error

### DIFF
--- a/publishx.py
+++ b/publishx.py
@@ -134,12 +134,12 @@ class Publishx(slixmpp.ClientXMPP):
         elif version == 'rss20' or 'rss10' or 'atom10':
             if hasattr(entry, 'author'):
                 author = ET.SubElement(ent, "author")
-                name = ET.SubElement(ent, "author")
+                name = ET.SubElement(author, "author")
                 name.text = entry.author
             
                 if hasattr(entry.author, 'href'):
                     uri = ET.SubElement(author, "uri")
-                    uri.text = entry.authors[0].href
+                    uri.text = entry.author.href
                     
         item['payload'] = ent
 

--- a/publishx.py
+++ b/publishx.py
@@ -134,7 +134,7 @@ class Publishx(slixmpp.ClientXMPP):
         elif version == 'rss20' or 'rss10' or 'atom10':
             if hasattr(entry, 'author'):
                 author = ET.SubElement(ent, "author")
-                name = ET.SubElement(author, "author")
+                name = ET.SubElement(author, "name")
                 name.text = entry.author
             
                 if hasattr(entry.author, 'href'):


### PR DESCRIPTION
Greetings!

It would be good to inform that I did not test this part of code that handles authors of which changes can be seen in this PR.

I have questions:

### Property "name"
Why is attribute 'authors' being handled differently?

**Atom 0.3:** `name` gets `author` to be a sub-element of it, and "name" as attribute.
```
author = ET.SubElement(node_entry, "author")
name = ET.SubElement(author, "name")
```
**Atom 1.0:** `name` gets `node_entry` to be a sub-element of it, and "author" as attribute, which is exectly the same as the variable `author` above it.
```
author = ET.SubElement(node_entry, "author")
name = ET.SubElement(node_entry, "author")
```

### Error
This code checks for attribute 'author' (see `if hasattr(entry, 'author'):`), and for `uri.text` it attempts to get value from `authors` (see `uri.text = entry.authors[0].href`).
```
elif version == 'rss20' or 'rss10' or 'atom10':
    if hasattr(entry, 'author'):
        author = ET.SubElement(node_entry, "author")
        name = ET.SubElement(node_entry, "author")
        name.text = entry.author
        if hasattr(entry.author, 'href'):
            uri = ET.SubElement(author, "uri")
            uri.text = entry.authors[0].href
```