### PR TITLE
Check whether node exists before attempting to create it

### DIFF
--- a/publishx.py
+++ b/publishx.py
@@ -55,14 +55,14 @@ class Publishx(slixmpp.ClientXMPP):
                       ftype='text-single',
                       value=description)
 
-        task = iq.send(timeout=5)
-        try:
-            await task
-        except IqError as e:
-            if e.etype == 'cancel' and e.condition == 'conflict':
-                print(colored('!! node %s is already created, assuming its configuration is correct' % node, 'yellow'))
-                return
-            raise
+        node_exist = await self.plugin['xep_0060'].get_node_config(server, node)
+        if not node_exist:
+            task = iq.send(timeout=5)
+            try:
+                await task
+            except (IqError, IqTimeout) as e:
+                print('Error:', str(e))
+                raise
 
     async def publish(self, server, node, entry, version):
         iq = self.Iq(stype="set", sto=server)


### PR DESCRIPTION
Check whether a node exists, by mean of attempting to read its configurations, before attempting to create it.

---

I did not test this code with AtomToPubSub. Please feel free to change it to what ever you want.